### PR TITLE
Change demo link to HTTP, to prevent blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alpha but usable, see key features and backlog below.
 Live Examples
 ---------------
 
-[Click here for a live example of this library in use!](https://rawgithub.com/chafey/cornerstoneWADOImageLoader/master/examples/index.html)
+[Click here for a live example of this library in use!](http://rawgithub.com/chafey/cornerstoneWADOImageLoader/master/examples/index.html)
 
 You can also see it in action with the
 [cornerstoneDemo application](https://github.com/chafey/cornerstoneDemo).


### PR DESCRIPTION
The link to the demo uses HTTPS, but if you try to load WADO's from external sites served with HTTP, they get blocked. Changing to HTTP seems to do the trick for external HTTP WADO URL's .
