### PR TITLE
fix(180): Avoid throwing exception for missing transfer syntax decoder

### DIFF
--- a/src/imageLoader/decodeImageFrame.js
+++ b/src/imageLoader/decodeImageFrame.js
@@ -79,7 +79,9 @@ function decodeImageFrame (imageFrame, transferSyntax, pixelData, canvas, option
    }
    */
 
-  throw new Error(`No decoder for transfer syntax ${transferSyntax}`);
+  return new Promise((resolve, reject) => {
+    reject(new Error(`No decoder for transfer syntax ${transferSyntax}`));
+  });
 }
 
 export default decodeImageFrame;


### PR DESCRIPTION
## Issue: 
An Exception is being triggered once the ImageLoader does not find a proper decoder. 

## Fix: 
Instead of throwing the exception we are now returning a rejected promise passing the error as a parameter. 