### PR TITLE
Update README: Project file links from rawgit to unpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ Install
 
 Get the distributed unminimized files:
 
-* [cornerstoneWADOImageLoader.js](https://raw.githubusercontent.com/cornerstonejs/cornerstoneWADOImageLoader/master/dist/cornerstoneWADOImageLoader.js)
-* [cornerstoneWADOImageLoaderCodecs.js](https://raw.githubusercontent.com/cornerstonejs/cornerstoneWADOImageLoader/master/dist/cornerstoneWADOImageLoaderCodecs.js)
-* [cornerstoneWADOImageLoaderWebWorker.js](https://raw.githubusercontent.com/cornerstonejs/cornerstoneWADOImageLoader/master/dist/cornerstoneWADOImageLoaderWebWorker.js)
+* [cornerstoneWADOImageLoader.js](https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoader.js)
+* [cornerstoneWADOImageLoaderCodecs.js](https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderCodecs.js)
+* [cornerstoneWADOImageLoaderWebWorker.js](https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderWebWorker.js)
 
 or the distributed minimized files:
 
-* [cornerstoneWADOImageLoader.min.js](https://raw.githubusercontent.com/cornerstonejs/cornerstoneWADOImageLoader/master/dist/cornerstoneWADOImageLoader.min.js)
-* [cornerstoneWADOImageLoaderCodecs.min.js](https://raw.githubusercontent.com/cornerstonejs/cornerstoneWADOImageLoader/master/dist/cornerstoneWADOImageLoaderCodecs.min.js)
-* [cornerstoneWADOImageLoaderWebWorker.min.js](https://raw.githubusercontent.com/cornerstonejs/cornerstoneWADOImageLoader/master/dist/cornerstoneWADOImageLoaderWebWorker.min.js)
+* [cornerstoneWADOImageLoader.min.js](https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoader.min.js)
+* [cornerstoneWADOImageLoaderCodecs.min.js](https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderCodecs.min.js)
+* [cornerstoneWADOImageLoaderWebWorker.min.js](https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderWebWorker.min.js)
 
 Usage
 -------


### PR DESCRIPTION
# Changes
- Update README pointing all referencies to dist files to www.unpkg.com instead of rawgit. 