### PR TITLE
Bugfix189: 'window undefined'

### DIFF
--- a/config/webpack/webpack-base.js
+++ b/config/webpack/webpack-base.js
@@ -16,6 +16,7 @@ module.exports = {
     filename: '[name].js',
     library: '[name]',
     libraryTarget: 'umd',
+    globalObject: 'this',
     path: outputPath,
     umdNamedDefine: true
   },

--- a/examples/customWebWorkerTask/index.html
+++ b/examples/customWebWorkerTask/index.html
@@ -136,26 +136,7 @@
 
 <script>
     // Initialize the web worker manager with our custom web worker task
-    let config = {
-        maxWebWorkers: navigator.hardwareConcurrency || 1,
-        startWebWorkersOnDemand: true,
-        webWorkerPath : '../../dist/cornerstoneWADOImageLoaderWebWorker.js',
-        webWorkerTaskPaths: [
-
-            '../examples/customWebWorkerTask/convolveTask.js'
-
-        ],
-        taskConfiguration: {
-            'decodeTask' : {
-                loadCodecsOnStartup : true,
-                initializeCodecsOnStartup: false,
-                codecsPath: '../dist/cornerstoneWADOImageLoaderCodecs.js',
-                usePDFJS: false
-            }
-        }
-    };
-
-    // Lines ONLY required for this example to run without building the project
+    // window.customWebWorkerConfig contains custom web worker config and a fallback in case there is no dist folder
     config = window.customWebWorkerConfig;
 
     cornerstoneWADOImageLoader.external.cornerstone = cornerstone;

--- a/examples/utils/customWebWorkersConfig.js
+++ b/examples/utils/customWebWorkersConfig.js
@@ -5,9 +5,26 @@ function getBlobUrl (url) {
   return baseUrl.createObjectURL(blob);
 }
 
-const webWorkerUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderWebWorker.min.js');
-const codecsUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderCodecs.js');
+function UrlExists (url) {
+  const http = new XMLHttpRequest();
+
+  http.open('HEAD', url, false);
+  http.send();
+
+  return http.status !== 404;
+}
+
+let webWorkerUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderWebWorker.min.js');
+let codecsUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderCodecs.js');
 const domain = window.location.origin;
+
+if (UrlExists('../../dist/cornerstoneWADOImageLoaderWebWorker.min.js')) {
+  webWorkerUrl = '../../dist/cornerstoneWADOImageLoaderWebWorker.min.js';
+}
+
+if (UrlExists('../../dist/cornerstoneWADOImageLoaderCodecs.js')) {
+  codecsUrl = '../dist/cornerstoneWADOImageLoaderCodecs.js';
+}
 
 window.customWebWorkerConfig = {
   maxWebWorkers: navigator.hardwareConcurrency || 1,

--- a/examples/utils/initializeWebWorkers.js
+++ b/examples/utils/initializeWebWorkers.js
@@ -7,8 +7,25 @@ function getBlobUrl (url) {
   return baseUrl.createObjectURL(blob);
 }
 
-const webWorkerUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderWebWorker.min.js');
-const codecsUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderCodecs.js');
+function UrlExists (url) {
+  const http = new XMLHttpRequest();
+
+  http.open('HEAD', url, false);
+  http.send();
+
+  return http.status !== 404;
+}
+
+let webWorkerUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderWebWorker.min.js');
+let codecsUrl = getBlobUrl('https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoaderCodecs.js');
+
+if (UrlExists('../../dist/cornerstoneWADOImageLoaderWebWorker.min.js')) {
+  webWorkerUrl = '../../dist/cornerstoneWADOImageLoaderWebWorker.min.js';
+}
+
+if (UrlExists('../../dist/cornerstoneWADOImageLoaderCodecs.js')) {
+  codecsUrl = '../dist/cornerstoneWADOImageLoaderCodecs.js';
+}
 
 try {
   window.cornerstoneWADOImageLoader.webWorkerManager.initialize({


### PR DESCRIPTION
## Changes
- Add a config option on webpack in order to fix the issue (based in the solution for this issue https://github.com/webpack/webpack/issues/6677) 
- Adding some verification in the examples config, in case we have dist folder, do not use unpkg files

## Required action
We need to release a new patch in order to fix the files we were using on unpkg, because the examples rely on them. 
