### PR TITLE
update calculateMinMax strict mode behavior

### DIFF
--- a/examples/utils/initializeWebWorkers.js
+++ b/examples/utils/initializeWebWorkers.js
@@ -39,7 +39,7 @@ try {
         initializeCodecsOnStartup: false,
         codecsPath: codecsUrl,
         usePDFJS: false,
-        strict: false
+        strict: true
       }
     }
   });

--- a/src/shared/calculateMinMax.js
+++ b/src/shared/calculateMinMax.js
@@ -12,8 +12,10 @@ import getMinMax from './getMinMax.js';
  */
 export default function calculateMinMax (imageFrame, strict = true) {
   const minMax = getMinMax(imageFrame.pixelData);
+  const mustAssign = !(isNumber(imageFrame.smallestPixelValue) && isNumber(imageFrame.largestPixelValue));
 
-  if (strict === true) {
+
+  if (strict === true && !mustAssign) {
     if (imageFrame.smallestPixelValue !== minMax.min) {
       console.warn('Image smallestPixelValue tag is incorrect. Rendering performance will suffer considerably.');
     }
@@ -25,4 +27,8 @@ export default function calculateMinMax (imageFrame, strict = true) {
     imageFrame.smallestPixelValue = minMax.min;
     imageFrame.largestPixelValue = minMax.max;
   }
+}
+
+function isNumber(numValue) {
+  return typeof numValue === "number";
 }

--- a/src/shared/calculateMinMax.js
+++ b/src/shared/calculateMinMax.js
@@ -8,9 +8,10 @@ import getMinMax from './getMinMax.js';
  * Otherwise, correct them automatically.
  *
  * @param {Object} imageFrame
- * @param {Boolean} strict
+ * @param {Boolean} strict If 'strict' is true, log to the console a warning if these values do not match.
+ * Otherwise, correct them automatically.Default is true.
  */
-export default function calculateMinMax (imageFrame, strict = false) {
+export default function calculateMinMax (imageFrame, strict = true) {
   const minMax = getMinMax(imageFrame.pixelData);
   const mustAssign = !(isNumber(imageFrame.smallestPixelValue) && isNumber(imageFrame.largestPixelValue));
 

--- a/src/shared/calculateMinMax.js
+++ b/src/shared/calculateMinMax.js
@@ -10,7 +10,7 @@ import getMinMax from './getMinMax.js';
  * @param {Object} imageFrame
  * @param {Boolean} strict
  */
-export default function calculateMinMax (imageFrame, strict = true) {
+export default function calculateMinMax (imageFrame, strict = false) {
   const minMax = getMinMax(imageFrame.pixelData);
   const mustAssign = !(isNumber(imageFrame.smallestPixelValue) && isNumber(imageFrame.largestPixelValue));
 

--- a/test/shared/calculateMinMax_test.js
+++ b/test/shared/calculateMinMax_test.js
@@ -28,4 +28,30 @@ describe('#calculateMinMax', function () {
     expect(this.imageFrame.smallestPixelValue).to.be.equal(-1);
     expect(this.imageFrame.largestPixelValue).to.be.equal(10);
   });
+
+  it('should update the smallest and largest pixel values regardless of strict value', function () {
+    let strict = false;
+    this.imageFrame.smallestPixelValue = undefined;
+    this.imageFrame.largestPixelValue = undefined;
+
+    // ACT
+    calculateMinMax(this.imageFrame, strict);
+
+    // ASSERT
+    expect(this.imageFrame.smallestPixelValue).to.be.equal(1);
+    expect(this.imageFrame.largestPixelValue).to.be.equal(9);
+
+    strict = true;
+
+    this.imageFrame.smallestPixelValue = undefined;
+    this.imageFrame.largestPixelValue = undefined;
+
+    // ACT
+    calculateMinMax(this.imageFrame, strict);
+
+    // ASSERT
+    expect(this.imageFrame.smallestPixelValue).to.be.equal(1);
+    expect(this.imageFrame.largestPixelValue).to.be.equal(9);
+  });
+
 });


### PR DESCRIPTION
The method now behaves as follow:
1. If **imageFrame.smallestPixelValue** Or **imageFrame.largestPixelValue** are not defined then we calculate min/max regardless of strict mode.
2. ~~Strict mode is **false** by default. This is so the new configuration is not breaking old implementation.~~