### PR TITLE
Increasing integration tests timeout

### DIFF
--- a/test/decoders_test.js
+++ b/test/decoders_test.js
@@ -40,7 +40,7 @@ describe('Test lossless TransferSyntaxes decoding', function () {
   let uncompressedImage = null;
 
   before(function (done) {
-
+    this.timeout(5000);
     // loads uncompressed study (the original one)
     const imageId = `${url}${base}`;
     const parsedImageId = parseImageId(imageId);

--- a/test/imageLoader/wadouri/metaDataProvider_test.js
+++ b/test/imageLoader/wadouri/metaDataProvider_test.js
@@ -36,6 +36,7 @@ describe('#wadouri > metadaProvider', function () {
   const imageId = 'dicomweb://localhost:9876/base/testImages/no-pixel-spacing.dcm';
 
   it('should return columnPixelSpacing undefined if pixelSpacing is undefined', function (done) {
+    this.timeout(5000);
     loadImage(imageId).promise.then(() => {
       const imagePlaneModule = external.cornerstone.metaData.get('imagePlaneModule', imageId);
       const { columnPixelSpacing } = imagePlaneModule;
@@ -50,6 +51,7 @@ describe('#wadouri > metadaProvider', function () {
   });
 
   it('should return columnPixelSpacing undefined if pixelSpacing is undefined', function (done) {
+    this.timeout(5000);
     loadImage(imageId).promise.then(() => {
       const imagePlaneModule = external.cornerstone.metaData.get('imagePlaneModule', imageId);
       const { rowPixelSpacing } = imagePlaneModule;

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -64,6 +64,7 @@ describe('loadImage', function () {
     const filename = `${base}_${name}_${transferSyntaxUid}.dcm`;
 
     it(`should properly load ${name}`, function (done) {
+      this.timeout(5000);
       const imageId = `${url}${filename}`;
 
       console.time(name);
@@ -88,6 +89,7 @@ describe('loadImage', function () {
   });
 
   it('should result in an error when the DICOM file has no pixelData', (done) => {
+    this.timeout(5000);
     const imageId = `${url}no-pixel-data.dcm`;
     let loadObject;
 

--- a/test/lossyImagesDecoding_test.js
+++ b/test/lossyImagesDecoding_test.js
@@ -32,6 +32,7 @@ describe('Test lossy TransferSyntaxes decoding', function () {
 
   before(function (done) {
     // loads uncompressed study (the original one)
+    this.timeout(5000);
     const imageId = `${url}${base}`;
     const parsedImageId = parseImageId(imageId);
 
@@ -72,6 +73,7 @@ describe('Test lossy TransferSyntaxes decoding', function () {
     const filename = `${base}_${name}_${transferSyntaxUid}.dcm`;
 
     it(`should properly decode ${name}`, function (done) {
+      this.timeout(5000);
       const imageId = `${url}${filename}`;
       const parsedImageId = parseImageId(imageId);
       const dataSetPromise = dataSetCacheManager.load(parsedImageId.url, xhrRequest, imageId);


### PR DESCRIPTION
Increasing integration tests timeout to 5000ms. They are heavy tests so needs more time to run on travisCI.
