### PR TITLE
feat(options.beforeSend): Add useful things to to beforeSend

### DIFF
--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -11,7 +11,7 @@ function xhrRequest (url, imageId, headers = {}, params = {}) {
 
     xhr.open('get', url, true);
     xhr.responseType = 'arraybuffer';
-    options.beforeSend(xhr, imageId);
+    options.beforeSend(xhr, imageId, headers, params);
     Object.keys(headers).forEach(function (key) {
       xhr.setRequestHeader(key, headers[key]);
     });


### PR DESCRIPTION
Add headers object and parameters to the beforeSend callback to simplify transfer-syntax specification