### PR TITLE
Wait until beforeSend option is finished.

### DIFF
--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -6,12 +6,12 @@ function xhrRequest (url, imageId, headers = {}, params = {}) {
   const options = getOptions();
 
   // Make the request for the DICOM P10 SOP Instance
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
     xhr.open('get', url, true);
     xhr.responseType = 'arraybuffer';
-    options.beforeSend(xhr, imageId, headers, params);
+    await options.beforeSend(xhr, imageId, headers, params);
     Object.keys(headers).forEach(function (key) {
       xhr.setRequestHeader(key, headers[key]);
     });


### PR DESCRIPTION
We propose to add **await** where the _beforeSend_ method is called to wait until it is finished. That is because _beforeSend_ can contain a token verification and renewal tasks that takes a while to complete. In our case, when a token has to be refreshed, the new token is requested to an external authentication server which is separated from the PACS resources. So, it's required to wait for the new token before proceed with the image loading.