### PR TITLE
DICOM Overlays 

### DIFF
--- a/src/imageLoader/wadors/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadors/metaData/metaDataProvider.js
@@ -130,6 +130,47 @@ function metaDataProvider (type, imageId) {
     };
   }
 
+  if (type === 'overlayPlaneModule') {
+    const overlays = [];
+
+    for (let overlayGroup = 0x00; overlayGroup <= 0x1E; overlayGroup += 0x02) {
+      let groupStr = `x60${overlayGroup.toString(16)}`;
+      if (groupStr.length === 4) {
+        groupStr = `x600${overlayGroup.toString(16)}`;
+      }
+
+      const data = getValue(metaData[`${groupStr}3000`]);
+      if (!data) {
+        continue;
+      }
+
+      const pixelData = [];
+      for (let i = 0; i < data.length; i++) {
+        for (let k = 0; k < 8; k++) {
+          const byte_as_int = metaData.Value[data.dataOffset + i];
+          pixelData[i * 8 + k] = (byte_as_int >> k) & 0b1; // eslint-disable-line no-bitwise
+        }
+      }
+
+      overlays.push({
+        rows: getNumberValue(metaData[`${groupStr}0010`]),
+        columns: getNumberValue(metaData[`${groupStr}0011`]),
+        type: getValue(metaData[`${groupStr}0040`]),
+        x: getNumberValue(metaData[`${groupStr}0050`], 1) - 1,
+        y: getNumberValue(metaData[`${groupStr}0050`], 0) - 1,
+        pixelData,
+        description: getValue(metaData[`${groupStr}0022`]),
+        label: getValue(metaData[`${groupStr}1500`]),
+        roiArea: getValue(metaData[`${groupStr}1301`]),
+        roiMean: getValue(metaData[`${groupStr}1302`]),
+        roiStandardDeviation: getValue(metaData[`${groupStr}1303`])
+      });
+    }
+
+    return {
+      overlays
+    };
+  }
 }
 
 export default metaDataProvider;

--- a/src/imageLoader/wadouri/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadouri/metaData/metaDataProvider.js
@@ -121,6 +121,48 @@ function metaDataProvider (type, imageId) {
       }
     };
   }
+
+  if (type === 'overlayPlaneModule') {
+    const overlays = [];
+
+    for (let overlayGroup = 0x00; overlayGroup <= 0x1E; overlayGroup += 0x02) {
+      let groupStr = `x60${overlayGroup.toString(16)}`;
+      if (groupStr.length === 4) {
+        groupStr = `x600${overlayGroup.toString(16)}`;
+      }
+
+      const data = dataSet.elements[`${groupStr}3000`];
+      if (!data) {
+        continue;
+      }
+
+      const pixelData = [];
+      for (let i = 0; i < data.length; i++) {
+        for (let k = 0; k < 8; k++) {
+          const byte_as_int = dataSet.byteArray[data.dataOffset + i];
+          pixelData[i * 8 + k] = (byte_as_int >> k) & 0b1; // eslint-disable-line no-bitwise
+        }
+      }
+
+      overlays.push({
+        rows: dataSet.uint16(`${groupStr}0010`),
+        columns: dataSet.uint16(`${groupStr}0011`),
+        type: dataSet.string(`${groupStr}0040`),
+        x: dataSet.int16(`${groupStr}0050`, 1) - 1,
+        y: dataSet.int16(`${groupStr}0050`, 0) - 1,
+        pixelData,
+        description: dataSet.string(`${groupStr}0022`),
+        label: dataSet.string(`${groupStr}1500`),
+        roiArea: dataSet.string(`${groupStr}1301`),
+        roiMean: dataSet.string(`${groupStr}1302`),
+        roiStandardDeviation: dataSet.string(`${groupStr}1303`)
+      });
+    }
+
+    return {
+      overlays
+    };
+  }
 }
 
 export default metaDataProvider;


### PR DESCRIPTION
Adds 'overlayPlaneModule' type returning an array of DICOM overlays.
This array is then added the 'overlays' propertry of the image.

This is then read by the overlays tool see - [cornerstonejs/cornerstoneTools#809](https://github.com/cornerstonejs/cornerstoneTools/pull/809)

see issue [cornerstonejs/cornerstoneTools#780](https://github.com/cornerstonejs/cornerstoneTools/issues/780)
see DICOM overlays standard - http://dicom.nema.org/dicom/2013/output/chtml/part03/sect_C.9.html