### PR TITLE
switch to readAsDataURL

### DIFF
--- a/src/imageLoader/decodeJPEGBaseline8BitColor.js
+++ b/src/imageLoader/decodeJPEGBaseline8BitColor.js
@@ -1,42 +1,15 @@
 import getMinMax from '../shared/getMinMax.js';
 
-/**
- * Special decoder for 8 bit jpeg that leverages the browser's built in JPEG decoder for increased performance
- */
-
-function arrayBufferToString (buffer) {
-  return binaryToString(String.fromCharCode.apply(null, Array.prototype.slice.apply(new Uint8Array(buffer))));
-}
-
-function binaryToString (binary) {
-  let error;
-
-  try {
-    return decodeURIComponent(escape(binary));
-  } catch (_error) {
-    error = _error;
-    if (error instanceof URIError) {
-      return binary;
-    }
-    throw error;
-
-  }
-}
-
 function decodeJPEGBaseline8BitColor (imageFrame, pixelData, canvas) {
+  console.log('decodeJPEGBaseline8BitColor');
+
   const start = new Date().getTime();
   const imgBlob = new Blob([pixelData], { type: 'image/jpeg' });
 
   return new Promise((resolve, reject) => {
     const fileReader = new FileReader();
 
-    if (fileReader.readAsBinaryString === undefined) {
-      fileReader.readAsArrayBuffer(imgBlob);
-    } else {
-      fileReader.readAsBinaryString(imgBlob); // doesn't work on IE11
-    }
-
-    fileReader.onload = function () {
+    fileReader.onload = function (e) {
       const img = new Image();
 
       img.onload = function () {
@@ -67,16 +40,14 @@ function decodeJPEGBaseline8BitColor (imageFrame, pixelData, canvas) {
         reject(error);
       };
 
-      if (fileReader.readAsBinaryString === undefined) {
-        img.src = `data:image/jpeg;base64,${window.btoa(arrayBufferToString(fileReader.result))}`;
-      } else {
-        img.src = `data:image/jpeg;base64,${window.btoa(fileReader.result)}`; // doesn't work on IE11
-      }
+      img.src = e.target.result;
     };
 
-    fileReader.onerror = (e) => {
+    fileReader.onerror = function (e) {
       reject(e);
     };
+
+    fileReader.readAsDataURL(imgBlob);
   });
 }
 

--- a/src/imageLoader/decodeJPEGBaseline8BitColor.js
+++ b/src/imageLoader/decodeJPEGBaseline8BitColor.js
@@ -1,8 +1,6 @@
 import getMinMax from '../shared/getMinMax.js';
 
 function decodeJPEGBaseline8BitColor (imageFrame, pixelData, canvas) {
-  console.log('decodeJPEGBaseline8BitColor');
-
   const start = new Date().getTime();
   const imgBlob = new Blob([pixelData], { type: 'image/jpeg' });
 


### PR DESCRIPTION
The existing codebase uses readAsBinaryString which seems to fail in latest Chrome.

Trying to load ultrasound JPEG Baseline 8Bit Color images fails in latest chrome. This is especially problematic when trying to process frames of a multiframe file.

In general the readAsBinaryString is the wrong API to use here as the data already arrives as a URL so readAsDataURL works much better and is much simpler.

