### PR TITLE
Handle decoder exceptions

### DIFF
--- a/src/imageLoader/webWorkerManager.js
+++ b/src/imageLoader/webWorkerManager.js
@@ -97,7 +97,9 @@ function handleMessageFromWorker (msg) {
   } else {
     const start = webWorkers[msg.data.workerIndex].task.start;
 
-    webWorkers[msg.data.workerIndex].task.deferred.resolve(msg.data.result);
+    const action = msg.data.status === 'success' ? 'resolve' : 'reject';
+    webWorkers[msg.data.workerIndex].task.deferred[action](msg.data.result);
+
     webWorkers[msg.data.workerIndex].task = undefined;
 
     statistics.numTasksExecuting--;

--- a/src/webWorker/webWorker.js
+++ b/src/webWorker/webWorker.js
@@ -93,14 +93,24 @@ self.onmessage = function (msg) {
 
   // dispatch the message if there is a handler registered for it
   if (taskHandlers[msg.data.taskType]) {
-    taskHandlers[msg.data.taskType].handler(msg.data, function (result, transferList) {
+    try {
+      taskHandlers[msg.data.taskType].handler(msg.data, function (result, transferList) {
+        self.postMessage({
+          taskType: msg.data.taskType,
+          status: 'success',
+          result,
+          workerIndex: msg.data.workerIndex
+        }, transferList);
+      });
+    } catch (error) {
+      console.log(`task ${msg.data.taskType} failed - ${error}`);
       self.postMessage({
         taskType: msg.data.taskType,
-        status: 'success',
-        result,
+        status: 'failed',
+        result: error,
         workerIndex: msg.data.workerIndex
-      }, transferList);
-    });
+      });
+    }
 
     return;
   }

--- a/src/webWorker/webWorker.js
+++ b/src/webWorker/webWorker.js
@@ -103,11 +103,11 @@ self.onmessage = function (msg) {
         }, transferList);
       });
     } catch (error) {
-      console.log(`task ${msg.data.taskType} failed - ${error}`);
+      console.log(`task ${msg.data.taskType} failed - ${error.message}`);
       self.postMessage({
         taskType: msg.data.taskType,
         status: 'failed',
-        result: error,
+        result: error.message,
         workerIndex: msg.data.workerIndex
       });
     }


### PR DESCRIPTION
This PR makes Wado correctly handle decoder errors.

If for example the Jpeg decoder  raises the `'Unsupported color mode'` here https://github.com/cornerstonejs/cornerstoneWADOImageLoader/blob/master/codecs/jpeg.js#L834

The exception is never caught which means the webworker never sends a failed message to the UI and the UI cannot respond.

The expected behaviour which is fixed with this PR is for decoder exceptions to cause the `EVENTS.IMAGE_LOAD_FAILED` to be sent in the UI
