### PR TITLE
Error interceptor

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,28 @@
+# Configuration
+
+The Cornerstone WADO Image Loader can be configured by the following:
+
+```js
+cornerstoneWADOImageLoader.configure(options);
+```
+
+Where options can have the following properties:
+
+- beforeSend - A callback that is executed before a network request. passes the
+  `XMLHttpRequest` object.
+- onloadend - Callback triggered when downloading an image ends. Passes the
+  event and params object.
+- onreadystatechange - Callback triggered on state change of request. Passes the
+  event and params object.
+- onprogress - Callback triggered when download progress event is fired.
+  PoProgress. Passes the event and params object.
+- errorInterceptor - Callback which may be used to deal with errors. Passes an
+  Error object with these additional properties:
+  - `request` - The `XMLHttpRequest` object.
+  - `response` - The `response`, if any.
+  - `status` - The HTTP `status` code.
+- useWebWorkers - Whethere to decode in web workers.
+- imageCreated - Callback allowing modification of newly created image objects.
+- decodeConfig - The configuration for the decoder - `usePDFJS` to use OHIF
+  image-JPEG2000 https://github.com/OHIF/image-JPEG2000.
+- strict - Whether strict mode for image decoding is on.

--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -78,6 +78,9 @@ function xhrRequest(url, imageId, headers = {}, params = {}) {
         if (xhr.status === 200) {
           resolve(xhr.response, xhr);
         } else {
+          if (typeof options.errorInterceptor === 'function') {
+            options.errorInterceptor(xhr);
+          }
           // request failed, reject the Promise
           reject(xhr);
         }
@@ -119,10 +122,16 @@ function xhrRequest(url, imageId, headers = {}, params = {}) {
       );
     };
     xhr.onerror = function() {
+      if (typeof options.errorInterceptor === 'function') {
+        options.errorInterceptor(xhr);
+      }
       reject(xhr);
     };
 
     xhr.onabort = function() {
+      if (typeof options.errorInterceptor === 'function') {
+        options.errorInterceptor(xhr);
+      }
       reject(xhr);
     };
     xhr.send();

--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -12,7 +12,6 @@ function xhrRequest(url, imageId, headers = {}, params = {}) {
       error.request = xhr;
       error.response = xhr.response;
       error.status = xhr.status;
-
       options.errorInterceptor(error);
     }
   };

--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -5,6 +5,18 @@ function xhrRequest(url, imageId, headers = {}, params = {}) {
   const { cornerstone } = external;
   const options = getOptions();
 
+  const errorInterceptor = xhr => {
+    if (typeof options.errorInterceptor === 'function') {
+      const error = new Error('request failed');
+
+      error.request = xhr;
+      error.response = xhr.response;
+      error.status = xhr.status;
+
+      options.errorInterceptor(error);
+    }
+  };
+
   // Make the request for the DICOM P10 SOP Instance
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -78,9 +90,7 @@ function xhrRequest(url, imageId, headers = {}, params = {}) {
         if (xhr.status === 200) {
           resolve(xhr.response, xhr);
         } else {
-          if (typeof options.errorInterceptor === 'function') {
-            options.errorInterceptor(xhr);
-          }
+          errorInterceptor(xhr);
           // request failed, reject the Promise
           reject(xhr);
         }
@@ -122,16 +132,12 @@ function xhrRequest(url, imageId, headers = {}, params = {}) {
       );
     };
     xhr.onerror = function() {
-      if (typeof options.errorInterceptor === 'function') {
-        options.errorInterceptor(xhr);
-      }
+      errorInterceptor(xhr);
       reject(xhr);
     };
 
     xhr.onabort = function() {
-      if (typeof options.errorInterceptor === 'function') {
-        options.errorInterceptor(xhr);
-      }
+      errorInterceptor(xhr);
       reject(xhr);
     };
     xhr.send();


### PR DESCRIPTION
Allows the user to add an error interceptor so that a user may intercept and process a request error at the app level.

This pattern for a library avoids an application having to try/catch each call across the application, and makes centralizing error management easier.