### PR TITLE
Update sizeInBytes to the byteLength of the array.

### DIFF
--- a/src/imageLoader/createImage.js
+++ b/src/imageLoader/createImage.js
@@ -138,7 +138,7 @@ function createImage(imageId, pixelData, transferSyntax, options) {
         maxPixelValue: imageFrame.largestPixelValue,
         rowPixelSpacing: imagePlaneModule.rowPixelSpacing,
         rows: imageFrame.rows,
-        sizeInBytes: imageFrame.pixelData.length,
+        sizeInBytes: imageFrame.pixelData.byteLength,
         slope: modalityLutModule.rescaleSlope
           ? modalityLutModule.rescaleSlope
           : 1,


### PR DESCRIPTION
It was currently incorrect for any image not storing data as 1 byte/pixel.