### PR TITLE
fix：Solve the problem that some DICOM files do not exist row/column pixelSpacing 

### DIFF
--- a/src/imageLoader/wadouri/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadouri/metaData/metaDataProvider.js
@@ -40,7 +40,11 @@ function metaDataProvider(type, imageId) {
     const imageOrientationPatient = getNumberValues(dataSet, 'x00200037', 6);
     const imagePositionPatient = getNumberValues(dataSet, 'x00200032', 3);
     const pixelSpacing = getNumberValues(dataSet, 'x00280030', 2);
-
+    
+    if(!pixelSpacing) {
+      pixelSpacing = getNumberValues(dataSet, 'x00181164', 2);
+    }
+    
     let columnPixelSpacing = null;
 
     let rowPixelSpacing = null;


### PR DESCRIPTION
Because of some DICOM files do not exist PixelSpacing（tag：0028,003），this results in the absence of a scale overlay tool，so we can use ImagerPixelSpacing （tag：0018,1164）to replace them。