### PR TITLE
fix: improvements for usage of targetBuffer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     JpxImage: true,
     CharLS: true,
     OpenJPEG: true,
+    SharedArrayBuffer: true,
   },
   rules: {
     'accessor-pairs': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cornerstone-wado-image-loader",
-  "version": "3.0.4",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/imageLoader/createImage.js
+++ b/src/imageLoader/createImage.js
@@ -5,6 +5,7 @@ import isColorImageFn from './isColorImage.js';
 import convertColorSpace from './convertColorSpace.js';
 import getMinMax from '../shared/getMinMax.js';
 import isJPEGBaseline8BitColor from './isJPEGBaseline8BitColor.js';
+import { getOptions } from './internal/options.js';
 
 let lastImageIdDrawn = '';
 
@@ -83,16 +84,33 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
     options
   );
 
+  const { decodeConfig } = getOptions();
+  const { convertFloatPixelDataToInt } = decodeConfig;
+
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line complexity
-    decodePromise.then(function handleDecodeResponse(imageFrame) {
+    decodePromise.then(function(imageFrame) {
       // If we have a target buffer that was written to in the
       // Decode task, point the image to it here.
       // We can't have done it within the thread incase it was a SharedArrayBuffer.
+      let alreadyTyped = false;
+
       if (options.targetBuffer) {
-        const { arrayBuffer, offset, length, type } = options.targetBuffer;
+        let offset, length;
+        // If we have a target buffer, write to that instead. This helps reduce memory duplication.
+
+        ({ offset, length } = options.targetBuffer);
+        const { arrayBuffer, type } = options.targetBuffer;
 
         let TypedArrayConstructor;
+
+        if (length === null || length === undefined) {
+          length = imageFrame.pixelDataLength;
+        }
+
+        if (offset === null || offset === undefined) {
+          offset = 0;
+        }
 
         switch (type) {
           case 'Uint8Array':
@@ -110,13 +128,25 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
             );
         }
 
-        const targetArray = new TypedArrayConstructor(
-          arrayBuffer,
-          offset,
-          length
-        );
+        if (length !== imageFrame.pixelDataLength) {
+          throw new Error(
+            'target array for image does not have the same length as the decoded image length.'
+          );
+        }
 
-        imageFrame.pixelData = targetArray;
+        // TypedArray.Set is api level and ~50x faster than copying elements even for
+        // Arrays of different types, which aren't simply memcpy ops.
+        let typedArray;
+
+        if (arrayBuffer) {
+          typedArray = new TypedArrayConstructor(arrayBuffer, offset, length);
+        } else {
+          typedArray = new TypedArrayConstructor(imageFrame.pixelData);
+        }
+
+        // If need to scale, need to scale correct array.
+        imageFrame.pixelData = typedArray;
+        alreadyTyped = true;
       }
 
       const imagePlaneModule =
@@ -132,7 +162,9 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
       // JPEGBaseline (8 bits) is already returning the pixel data in the right format (rgba)
       // because it's using a canvas to load and decode images.
       if (!isJPEGBaseline8BitColor(imageFrame, transferSyntax)) {
-        setPixelDataType(imageFrame);
+        if (!alreadyTyped) {
+          setPixelDataType(imageFrame);
+        }
 
         // convert color space
         if (isColorImage) {
@@ -185,10 +217,16 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
           : undefined,
         decodeTimeInMS: imageFrame.decodeTimeInMS,
         floatPixelData: undefined,
+        imageFrame,
       };
 
-      // add function to return pixel data
-      if (imageFrame.pixelData instanceof Float32Array) {
+      // If pixel data is intrinsically floating 32 array, we convert it to int for
+      // display in cornerstone. For other cases when pixel data is typed as
+      // Float32Array for scaling; this conversion is not needed.
+      if (
+        imageFrame.pixelData instanceof Float32Array &&
+        convertFloatPixelDataToInt
+      ) {
         const floatPixelData = imageFrame.pixelData;
         const results = convertToIntPixelData(floatPixelData);
 

--- a/src/imageLoader/imageIdToURI.js
+++ b/src/imageLoader/imageIdToURI.js
@@ -1,0 +1,12 @@
+/**
+ * Removes the data loader scheme from the imageId
+ *
+ * @param {string} imageId Image ID
+ * @returns {string} imageId without the data loader scheme
+ * @memberof Cache
+ */
+export default function imageIdToURI(imageId) {
+  const colonIndex = imageId.indexOf(':');
+
+  return imageId.substring(colonIndex + 1);
+}

--- a/src/imageLoader/internal/options.js
+++ b/src/imageLoader/internal/options.js
@@ -10,6 +10,7 @@ let options = {
   strict: false,
   useWebWorkers: true,
   decodeConfig: {
+    convertFloatPixelDataToInt: true,
     usePDFJS: false,
   },
 };

--- a/src/imageLoader/wadors/loadImage.js
+++ b/src/imageLoader/wadors/loadImage.js
@@ -63,7 +63,8 @@ function loadImage(imageId, options) {
 
   const promise = new Promise((resolve, reject) => {
     // TODO: load bulk data items that we might need
-    const mediaType = 'multipart/related; type="application/octet-stream"; transfer-syntax=*'; // 'image/dicom+jp2';
+    const mediaType =
+      'multipart/related; type="application/octet-stream"; transfer-syntax=*'; // 'image/dicom+jp2';
 
     // get the pixel data from the server
     getPixelData(uri, imageId, mediaType)

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -1,19 +1,27 @@
-let imageIds = [];
+import imageIdToURI from '../imageIdToURI.js';
+
+let metadataByImageURI = [];
 
 function add(imageId, metadata) {
-  imageIds[imageId] = metadata;
+  const imageURI = imageIdToURI(imageId);
+
+  metadataByImageURI[imageURI] = metadata;
 }
 
 function get(imageId) {
-  return imageIds[imageId];
+  const imageURI = imageIdToURI(imageId);
+
+  return metadataByImageURI[imageURI];
 }
 
 function remove(imageId) {
-  imageIds[imageId] = undefined;
+  const imageURI = imageIdToURI(imageId);
+
+  metadataByImageURI[imageURI] = undefined;
 }
 
 function purge() {
-  imageIds = [];
+  metadataByImageURI = [];
 }
 
 export default {

--- a/src/shared/scaling/scaleArray.js
+++ b/src/shared/scaling/scaleArray.js
@@ -1,15 +1,16 @@
 export default function scaleArray(array, scalingParameters) {
   const arrayLength = array.length;
+  const { rescaleSlope, rescaleIntercept, suvbw } = scalingParameters;
 
   if (scalingParameters.modality === 'PT') {
-    const { rescaleSlope, rescaleIntercept, suvbw } = scalingParameters;
+    if (typeof suvbw !== 'number') {
+      return;
+    }
 
     for (let i = 0; i < arrayLength; i++) {
       array[i] = suvbw * (array[i] * rescaleSlope + rescaleIntercept);
     }
   } else {
-    const { rescaleSlope, rescaleIntercept } = scalingParameters;
-
     for (let i = 0; i < arrayLength; i++) {
       array[i] = array[i] * rescaleSlope + rescaleIntercept;
     }


### PR DESCRIPTION
add convertFloatPixelDataToInt flag (default true)


Pushing to public branch from a private repo. This is used with upcoming Cornerstone volumetric functionality