### PR TITLE
fix: Load the palette color from a promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   },
   "dependencies": {
     "@cornerstonejs/codec-charls": "^0.1.1",
+    "@cornerstonejs/codec-libjpeg-turbo-12bit": "^0.2.0",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^0.0.7",
     "@cornerstonejs/codec-openjpeg": "^0.1.0",
     "dicom-parser": "^1.8.9",

--- a/src/imageLoader/colorSpaceConverters/convertPALETTECOLOR.js
+++ b/src/imageLoader/colorSpaceConverters/convertPALETTECOLOR.js
@@ -16,14 +16,21 @@ function convertLUTto8Bit(lut, shift) {
  *
  * @param {ImageFrame} imageFrame
  * @param {Uint8ClampedArray} rgbaBuffer
- * @returns {void}
+ * @returns {rgbaBuffer} as async function
  */
-export default function (imageFrame, rgbaBuffer) {
+export default async function (imageFrame, rgbaBuffer) {
   const numPixels = imageFrame.columns * imageFrame.rows;
   const pixelData = imageFrame.pixelData;
-  const rData = imageFrame.redPaletteColorLookupTableData;
-  const gData = imageFrame.greenPaletteColorLookupTableData;
-  const bData = imageFrame.bluePaletteColorLookupTableData;
+  const [rData, gData, bData] = await Promise.all([
+    imageFrame.redPaletteColorLookupTableData,
+    imageFrame.greenPaletteColorLookupTableData,
+    imageFrame.bluePaletteColorLookupTableData,
+  ]);
+
+  if (!rData || !gData || !bData) {
+    throw new Error(`Palette data not found in ${imageFrame}`);
+  }
+
   const len = imageFrame.redPaletteColorLookupTableData.length;
 
   let palIndex = 0;
@@ -54,4 +61,6 @@ export default function (imageFrame, rgbaBuffer) {
     rgbaBuffer[rgbaIndex++] = bDataCleaned[value];
     rgbaBuffer[rgbaIndex++] = 255;
   }
+
+  return rgbaBuffer;
 }

--- a/src/imageLoader/convertColorSpace.js
+++ b/src/imageLoader/convertColorSpace.js
@@ -34,7 +34,7 @@ export default function convertColorSpace(imageFrame, imageData) {
   } else if (imageFrame.photometricInterpretation === 'YBR_ICT') {
     convertRGB(imageFrame, rgbaBuffer);
   } else if (imageFrame.photometricInterpretation === 'PALETTE COLOR') {
-    convertPALETTECOLOR(imageFrame, rgbaBuffer);
+    return convertPALETTECOLOR(imageFrame, rgbaBuffer);
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL_422') {
     convertYBRFull422ByPixel(imageFrame.pixelData, rgbaBuffer);
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL') {

--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -33,8 +33,12 @@ function xhrRequest(url, imageId, defaultHeaders = {}, params = {}) {
     const headers = Object.assign({}, defaultHeaders, beforeSendHeaders);
 
     Object.keys(headers).forEach(function (key) {
-      if (headers[key] === null) return;
-      if (key === 'Accept' && url.indexOf('accept=') !== -1) return;
+      if (headers[key] === null) {
+        return;
+      }
+      if (key === 'Accept' && url.indexOf('accept=') !== -1) {
+        return;
+      }
       xhr.setRequestHeader(key, headers[key]);
     });
 


### PR DESCRIPTION
The palette colour data can come back as a promise, so that it is lazy loaded as required.  
The conversion from palette colour is fast, but there does seem to be a rerender somewhere that is relatively slow in the newer version - this doesn't seem to be related to the changes here as I can revert them and it is still slow, but version 4.0.4 was faster.

Changed to have the image loader use async instead of promises to deal with a deep nesting of things.
