### PR TITLE
fix: copy buffer to prevent oom in workers

### DIFF
--- a/src/imageLoader/wadouri/getUncompressedImageFrame.js
+++ b/src/imageLoader/wadouri/getUncompressedImageFrame.js
@@ -53,9 +53,7 @@ function getUncompressedImageFrame(dataSet, frameIndex) {
     }
 
     return new Uint8Array(
-      dataSet.byteArray.buffer,
-      frameOffset,
-      pixelsPerFrame
+      dataSet.byteArray.buffer.slice(frameOffset, frameOffset + pixelsPerFrame)
     );
   } else if (bitsAllocated === 16) {
     frameOffset = pixelDataOffset + frameIndex * pixelsPerFrame * 2;
@@ -64,9 +62,10 @@ function getUncompressedImageFrame(dataSet, frameIndex) {
     }
 
     return new Uint8Array(
-      dataSet.byteArray.buffer,
-      frameOffset,
-      pixelsPerFrame * 2
+      dataSet.byteArray.buffer.slice(
+        frameOffset,
+        frameOffset + pixelsPerFrame * 2
+      )
     );
   } else if (bitsAllocated === 1) {
     frameOffset = pixelDataOffset + frameIndex * pixelsPerFrame * 0.125;
@@ -82,9 +81,10 @@ function getUncompressedImageFrame(dataSet, frameIndex) {
     }
 
     return new Uint8Array(
-      dataSet.byteArray.buffer,
-      frameOffset,
-      pixelsPerFrame * 4
+      dataSet.byteArray.buffer.slice(
+        frameOffset,
+        frameOffset + pixelsPerFrame * 4
+      )
     );
   }
 


### PR DESCRIPTION
Large uncompressed multiframe data will send the full
arraybuffer in a typed view. For large uncompressed data
such as tomo these will result in OOM issues. This fix
pre-slices the typed array view so only used buffer
is sent via worker.postMessage.