### PR TITLE
perf: add option to use RGB instead of RGBA

### DIFF
--- a/src/imageLoader/colorSpaceConverters/convertRGBColorByPixel.js
+++ b/src/imageLoader/colorSpaceConverters/convertRGBColorByPixel.js
@@ -1,4 +1,4 @@
-export default function (imageFrame, rgbaBuffer) {
+export default function (imageFrame, colorBuffer, useRGBA) {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: rgbBuffer must not be undefined');
   }
@@ -10,12 +10,23 @@ export default function (imageFrame, rgbaBuffer) {
 
   let rgbIndex = 0;
 
-  let rgbaIndex = 0;
+  let bufferIndex = 0;
 
+  if (useRGBA) {
+    for (let i = 0; i < numPixels; i++) {
+      colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // red
+      colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // green
+      colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // blue
+      colorBuffer[bufferIndex++] = 255; // alpha
+    }
+
+    return;
+  }
+
+  // if RGB buffer
   for (let i = 0; i < numPixels; i++) {
-    rgbaBuffer[rgbaIndex++] = imageFrame[rgbIndex++]; // red
-    rgbaBuffer[rgbaIndex++] = imageFrame[rgbIndex++]; // green
-    rgbaBuffer[rgbaIndex++] = imageFrame[rgbIndex++]; // blue
-    rgbaBuffer[rgbaIndex++] = 255; // alpha
+    colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // red
+    colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // green
+    colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // blue
   }
 }

--- a/src/imageLoader/colorSpaceConverters/convertRGBColorByPixel.js
+++ b/src/imageLoader/colorSpaceConverters/convertRGBColorByPixel.js
@@ -24,9 +24,5 @@ export default function (imageFrame, colorBuffer, useRGBA) {
   }
 
   // if RGB buffer
-  for (let i = 0; i < numPixels; i++) {
-    colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // red
-    colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // green
-    colorBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // blue
-  }
+  colorBuffer.set(imageFrame);
 }

--- a/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.js
+++ b/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.js
@@ -1,4 +1,4 @@
-export default function (imageFrame, rgbaBuffer) {
+export default function (imageFrame, colorBuffer, useRGBA) {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: rgbBuffer must not be undefined');
   }
@@ -8,7 +8,7 @@ export default function (imageFrame, rgbaBuffer) {
 
   const numPixels = imageFrame.length / 3;
 
-  let rgbaIndex = 0;
+  let bufferIndex = 0;
 
   let rIndex = 0;
 
@@ -16,10 +16,21 @@ export default function (imageFrame, rgbaBuffer) {
 
   let bIndex = numPixels * 2;
 
+  if (useRGBA) {
+    for (let i = 0; i < numPixels; i++) {
+      colorBuffer[bufferIndex++] = imageFrame[rIndex++]; // red
+      colorBuffer[bufferIndex++] = imageFrame[gIndex++]; // green
+      colorBuffer[bufferIndex++] = imageFrame[bIndex++]; // blue
+      colorBuffer[bufferIndex++] = 255; // alpha
+    }
+
+    return;
+  }
+
+  // if RGB buffer
   for (let i = 0; i < numPixels; i++) {
-    rgbaBuffer[rgbaIndex++] = imageFrame[rIndex++]; // red
-    rgbaBuffer[rgbaIndex++] = imageFrame[gIndex++]; // green
-    rgbaBuffer[rgbaIndex++] = imageFrame[bIndex++]; // blue
-    rgbaBuffer[rgbaIndex++] = 255; // alpha
+    colorBuffer[bufferIndex++] = imageFrame[rIndex++]; // red
+    colorBuffer[bufferIndex++] = imageFrame[gIndex++]; // green
+    colorBuffer[bufferIndex++] = imageFrame[bIndex++]; // blue
   }
 }

--- a/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.js
+++ b/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.js
@@ -28,9 +28,5 @@ export default function (imageFrame, colorBuffer, useRGBA) {
   }
 
   // if RGB buffer
-  for (let i = 0; i < numPixels; i++) {
-    colorBuffer[bufferIndex++] = imageFrame[rIndex++]; // red
-    colorBuffer[bufferIndex++] = imageFrame[gIndex++]; // green
-    colorBuffer[bufferIndex++] = imageFrame[bIndex++]; // blue
-  }
+  colorBuffer.set(imageFrame);
 }

--- a/src/imageLoader/colorSpaceConverters/convertYBRFull422ByPixel.js
+++ b/src/imageLoader/colorSpaceConverters/convertYBRFull422ByPixel.js
@@ -1,4 +1,4 @@
-export default function (imageFrame, rgbaBuffer) {
+export default function (imageFrame, colorBuffer, useRGBA) {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: ybrBuffer must not be undefined');
   }
@@ -10,7 +10,30 @@ export default function (imageFrame, rgbaBuffer) {
 
   let ybrIndex = 0;
 
-  let rgbaIndex = 0;
+  let bufferIndex = 0;
+
+  if (useRGBA) {
+    for (let i = 0; i < numPixels; i += 2) {
+      const y1 = imageFrame[ybrIndex++];
+      const y2 = imageFrame[ybrIndex++];
+      const cb = imageFrame[ybrIndex++];
+      const cr = imageFrame[ybrIndex++];
+
+      colorBuffer[bufferIndex++] = y1 + 1.402 * (cr - 128); // red
+      colorBuffer[bufferIndex++] =
+        y1 - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+      colorBuffer[bufferIndex++] = y1 + 1.772 * (cb - 128); // blue
+      colorBuffer[bufferIndex++] = 255; // alpha
+
+      colorBuffer[bufferIndex++] = y2 + 1.402 * (cr - 128); // red
+      colorBuffer[bufferIndex++] =
+        y2 - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+      colorBuffer[bufferIndex++] = y2 + 1.772 * (cb - 128); // blue
+      colorBuffer[bufferIndex++] = 255; // alpha
+    }
+
+    return;
+  }
 
   for (let i = 0; i < numPixels; i += 2) {
     const y1 = imageFrame[ybrIndex++];
@@ -18,14 +41,14 @@ export default function (imageFrame, rgbaBuffer) {
     const cb = imageFrame[ybrIndex++];
     const cr = imageFrame[ybrIndex++];
 
-    rgbaBuffer[rgbaIndex++] = y1 + 1.402 * (cr - 128); // red
-    rgbaBuffer[rgbaIndex++] = y1 - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
-    rgbaBuffer[rgbaIndex++] = y1 + 1.772 * (cb - 128); // blue
-    rgbaBuffer[rgbaIndex++] = 255; // alpha
+    colorBuffer[bufferIndex++] = y1 + 1.402 * (cr - 128); // red
+    colorBuffer[bufferIndex++] =
+      y1 - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+    colorBuffer[bufferIndex++] = y1 + 1.772 * (cb - 128); // blue
 
-    rgbaBuffer[rgbaIndex++] = y2 + 1.402 * (cr - 128); // red
-    rgbaBuffer[rgbaIndex++] = y2 - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
-    rgbaBuffer[rgbaIndex++] = y2 + 1.772 * (cb - 128); // blue
-    rgbaBuffer[rgbaIndex++] = 255; // alpha
+    colorBuffer[bufferIndex++] = y2 + 1.402 * (cr - 128); // red
+    colorBuffer[bufferIndex++] =
+      y2 - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+    colorBuffer[bufferIndex++] = y2 + 1.772 * (cb - 128); // blue
   }
 }

--- a/src/imageLoader/colorSpaceConverters/convertYBRFullByPixel.js
+++ b/src/imageLoader/colorSpaceConverters/convertYBRFullByPixel.js
@@ -1,4 +1,4 @@
-export default function (imageFrame, rgbaBuffer) {
+export default function (imageFrame, colorBuffer, useRGBA) {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: ybrBuffer must not be undefined');
   }
@@ -10,16 +10,32 @@ export default function (imageFrame, rgbaBuffer) {
 
   let ybrIndex = 0;
 
-  let rgbaIndex = 0;
+  let bufferIndex = 0;
+
+  if (useRGBA) {
+    for (let i = 0; i < numPixels; i++) {
+      const y = imageFrame[ybrIndex++];
+      const cb = imageFrame[ybrIndex++];
+      const cr = imageFrame[ybrIndex++];
+
+      colorBuffer[bufferIndex++] = y + 1.402 * (cr - 128); // red
+      colorBuffer[bufferIndex++] =
+        y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+      colorBuffer[bufferIndex++] = y + 1.772 * (cb - 128); // blue
+      colorBuffer[bufferIndex++] = 255; // alpha
+    }
+
+    return;
+  }
 
   for (let i = 0; i < numPixels; i++) {
     const y = imageFrame[ybrIndex++];
     const cb = imageFrame[ybrIndex++];
     const cr = imageFrame[ybrIndex++];
 
-    rgbaBuffer[rgbaIndex++] = y + 1.402 * (cr - 128); // red
-    rgbaBuffer[rgbaIndex++] = y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
-    rgbaBuffer[rgbaIndex++] = y + 1.772 * (cb - 128); // blue
-    rgbaBuffer[rgbaIndex++] = 255; // alpha
+    colorBuffer[bufferIndex++] = y + 1.402 * (cr - 128); // red
+    colorBuffer[bufferIndex++] =
+      y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+    colorBuffer[bufferIndex++] = y + 1.772 * (cb - 128); // blue
   }
 }

--- a/src/imageLoader/colorSpaceConverters/convertYBRFullByPlane.js
+++ b/src/imageLoader/colorSpaceConverters/convertYBRFullByPlane.js
@@ -1,4 +1,4 @@
-export default function (imageFrame, rgbaBuffer) {
+export default function (imageFrame, colorBuffer, useRGBA) {
   if (imageFrame === undefined) {
     throw new Error('decodeRGB: ybrBuffer must not be undefined');
   }
@@ -8,7 +8,7 @@ export default function (imageFrame, rgbaBuffer) {
 
   const numPixels = imageFrame.length / 3;
 
-  let rgbaIndex = 0;
+  let bufferIndex = 0;
 
   let yIndex = 0;
 
@@ -16,14 +16,30 @@ export default function (imageFrame, rgbaBuffer) {
 
   let crIndex = numPixels * 2;
 
+  if (useRGBA) {
+    for (let i = 0; i < numPixels; i++) {
+      const y = imageFrame[yIndex++];
+      const cb = imageFrame[cbIndex++];
+      const cr = imageFrame[crIndex++];
+
+      colorBuffer[bufferIndex++] = y + 1.402 * (cr - 128); // red
+      colorBuffer[bufferIndex++] =
+        y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+      colorBuffer[bufferIndex++] = y + 1.772 * (cb - 128); // blue
+      colorBuffer[bufferIndex++] = 255; // alpha
+    }
+
+    return;
+  }
+
   for (let i = 0; i < numPixels; i++) {
     const y = imageFrame[yIndex++];
     const cb = imageFrame[cbIndex++];
     const cr = imageFrame[crIndex++];
 
-    rgbaBuffer[rgbaIndex++] = y + 1.402 * (cr - 128); // red
-    rgbaBuffer[rgbaIndex++] = y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
-    rgbaBuffer[rgbaIndex++] = y + 1.772 * (cb - 128); // blue
-    rgbaBuffer[rgbaIndex++] = 255; // alpha
+    colorBuffer[bufferIndex++] = y + 1.402 * (cr - 128); // red
+    colorBuffer[bufferIndex++] =
+      y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128); // green
+    colorBuffer[bufferIndex++] = y + 1.772 * (cb - 128); // blue
   }
 }

--- a/src/imageLoader/convertColorSpace.js
+++ b/src/imageLoader/convertColorSpace.js
@@ -7,38 +7,38 @@ import {
   convertPALETTECOLOR,
 } from './colorSpaceConverters/index.js';
 
-function convertRGB(imageFrame, rgbaBuffer) {
+function convertRGB(imageFrame, colorBuffer, useRGBA) {
   if (imageFrame.planarConfiguration === 0) {
-    convertRGBColorByPixel(imageFrame.pixelData, rgbaBuffer);
+    convertRGBColorByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else {
-    convertRGBColorByPlane(imageFrame.pixelData, rgbaBuffer);
+    convertRGBColorByPlane(imageFrame.pixelData, colorBuffer, useRGBA);
   }
 }
 
-function convertYBRFull(imageFrame, rgbaBuffer) {
+function convertYBRFull(imageFrame, colorBuffer, useRGBA) {
   if (imageFrame.planarConfiguration === 0) {
-    convertYBRFullByPixel(imageFrame.pixelData, rgbaBuffer);
+    convertYBRFullByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else {
-    convertYBRFullByPlane(imageFrame.pixelData, rgbaBuffer);
+    convertYBRFullByPlane(imageFrame.pixelData, colorBuffer, useRGBA);
   }
 }
 
-export default function convertColorSpace(imageFrame, imageData) {
-  const rgbaBuffer = imageData.data;
+export default function convertColorSpace(imageFrame, imageData, useRGBA) {
+  const colorBuffer = useRGBA ? imageData.data : imageData;
+
   // convert based on the photometric interpretation
-
   if (imageFrame.photometricInterpretation === 'RGB') {
-    convertRGB(imageFrame, rgbaBuffer);
+    convertRGB(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_RCT') {
-    convertRGB(imageFrame, rgbaBuffer);
+    convertRGB(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_ICT') {
-    convertRGB(imageFrame, rgbaBuffer);
+    convertRGB(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'PALETTE COLOR') {
-    convertPALETTECOLOR(imageFrame, rgbaBuffer);
+    convertPALETTECOLOR(imageFrame, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL_422') {
-    convertYBRFull422ByPixel(imageFrame.pixelData, rgbaBuffer);
+    convertYBRFull422ByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL') {
-    convertYBRFull(imageFrame, rgbaBuffer);
+    convertYBRFull(imageFrame, colorBuffer, useRGBA);
   } else {
     throw new Error(
       `No color space conversion for photometric interpretation ${imageFrame.photometricInterpretation}`

--- a/src/imageLoader/convertColorSpace.js
+++ b/src/imageLoader/convertColorSpace.js
@@ -23,9 +23,7 @@ function convertYBRFull(imageFrame, colorBuffer, useRGBA) {
   }
 }
 
-export default function convertColorSpace(imageFrame, imageData, useRGBA) {
-  const colorBuffer = useRGBA ? imageData.data : imageData;
-
+export default function convertColorSpace(imageFrame, colorBuffer, useRGBA) {
   // convert based on the photometric interpretation
   if (imageFrame.photometricInterpretation === 'RGB') {
     convertRGB(imageFrame, colorBuffer, useRGBA);

--- a/src/imageLoader/createImage.js
+++ b/src/imageLoader/createImage.js
@@ -71,7 +71,11 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
   // whether to use RGBA for color images, default true as cs-legacy uses RGBA
   // but we don't need RGBA in cs3d, and it's faster, and memory-efficient
   // in cs3d
-  const useRGBA = options.useRGBA ?? true;
+  let useRGBA = true;
+
+  if (options.useRGBA !== undefined) {
+    useRGBA = options.useRGBA;
+  }
 
   if (!pixelData || !pixelData.length) {
     return Promise.reject(new Error('The file does not contain image data.'));

--- a/src/imageLoader/createImage.js
+++ b/src/imageLoader/createImage.js
@@ -67,6 +67,31 @@ function setPixelDataType(imageFrame) {
   }
 }
 
+/**
+ * Removes the A from RGBA to return RGB buffer, this is used when the
+ * decoding happens with browser API which results in RGBA, but if useRGBA flag
+ * is set to false, we want to return RGB
+ *
+ * @param imageFrame - decoded image in RGBA
+ * @param targetBuffer - target buffer to write to
+ */
+function removeAFromRGBA(imageFrame, targetBuffer) {
+  const numPixels = imageFrame.length / 4;
+
+  let rgbIndex = 0;
+
+  let bufferIndex = 0;
+
+  for (let i = 0; i < numPixels; i++) {
+    targetBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // red
+    targetBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // green
+    targetBuffer[bufferIndex++] = imageFrame[rgbIndex++]; // blue
+    rgbIndex++; // skip alpha
+  }
+
+  return targetBuffer;
+}
+
 function createImage(imageId, pixelData, transferSyntax, options = {}) {
   // whether to use RGBA for color images, default true as cs-legacy uses RGBA
   // but we don't need RGBA in cs3d, and it's faster, and memory-efficient
@@ -158,6 +183,10 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
         alreadyTyped = true;
       }
 
+      if (!alreadyTyped) {
+        setPixelDataType(imageFrame);
+      }
+
       const imagePlaneModule =
         cornerstone.metaData.get('imagePlaneModule', imageId) || {};
       const voiLutModule =
@@ -168,47 +197,47 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
         cornerstone.metaData.get('sopCommonModule', imageId) || {};
       const isColorImage = isColorImageFn(imageFrame.photometricInterpretation);
 
-      // JPEGBaseline (8 bits) is already returning the pixel data in the right format (rgba)
-      // because it's using a canvas to load and decode images.
-      if (!isJPEGBaseline8BitColor(imageFrame, transferSyntax)) {
-        if (!alreadyTyped) {
-          setPixelDataType(imageFrame);
-        }
-
-        // convert color space
-        if (isColorImage) {
-          // setup the canvas context
+      if (isColorImage) {
+        // JPEGBaseline (8 bits) is already returning the pixel data in the right format (rgba)
+        // because it's using a canvas to load and decode images.
+        if (!isJPEGBaseline8BitColor(imageFrame, transferSyntax) && useRGBA) {
           canvas.height = imageFrame.rows;
           canvas.width = imageFrame.columns;
 
           const context = canvas.getContext('2d');
 
-          let imageData;
+          const imageData = context.createImageData(
+            imageFrame.columns,
+            imageFrame.rows
+          );
 
-          if (useRGBA) {
-            imageData = context.createImageData(
-              imageFrame.columns,
-              imageFrame.rows
-            );
-          } else {
-            const buffer = new ArrayBuffer(
-              3 * imageFrame.columns * imageFrame.rows
-            );
-
-            imageData = new Uint8ClampedArray(buffer);
-          }
-
-          convertColorSpace(imageFrame, imageData, useRGBA);
+          convertColorSpace(imageFrame, imageData.data, useRGBA);
 
           imageFrame.imageData = imageData;
           imageFrame.pixelData = imageData.data;
+        } else if (
+          isJPEGBaseline8BitColor(imageFrame, transferSyntax) &&
+          !useRGBA
+        ) {
+          // If we don't need the RGBA but the decoding is done with RGBA (the case
+          // for JPEG Baseline 8 bit color), AND the option specifies to use RGB (no RGBA)
+          // we need to remove the A channel from pixel data
+          const newPixelData = new imageFrame.pixelData.constructor(
+            (imageFrame.pixelData.length / 4) * 3
+          );
 
-          // calculate smallest and largest PixelValue of the converted pixelData
-          const minMax = getMinMax(imageFrame.pixelData);
-
-          imageFrame.smallestPixelValue = minMax.min;
-          imageFrame.largestPixelValue = minMax.max;
+          // remove the A from the RGBA of the imageFrame
+          imageFrame.pixelData = removeAFromRGBA(
+            imageFrame.pixelData,
+            newPixelData
+          );
         }
+
+        // calculate smallest and largest PixelValue of the converted pixelData
+        const minMax = getMinMax(imageFrame.pixelData);
+
+        imageFrame.smallestPixelValue = minMax.min;
+        imageFrame.largestPixelValue = minMax.max;
       }
 
       const image = {

--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -33,8 +33,12 @@ function xhrRequest(url, imageId, defaultHeaders = {}, params = {}) {
     const headers = Object.assign({}, defaultHeaders, beforeSendHeaders);
 
     Object.keys(headers).forEach(function (key) {
-      if (headers[key] === null) return;
-      if (key === 'Accept' && url.indexOf('accept=') !== -1) return;
+      if (headers[key] === null) {
+        return;
+      }
+      if (key === 'Accept' && url.indexOf('accept=') !== -1) {
+        return;
+      }
       xhr.setRequestHeader(key, headers[key]);
     });
 

--- a/src/imageLoader/wadors/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadors/metaData/metaDataProvider.js
@@ -157,6 +157,14 @@ function metaDataProvider(type, imageId) {
   if (type === 'overlayPlaneModule') {
     return getOverlayPlaneModule(metaData);
   }
+
+  // Note: this is not a DICOM module, but a useful metadata that can be
+  // retrieved from the image
+  if (type === 'transferSyntax') {
+    return {
+      transferSyntaxUID: getValue(metaData['00020010']),
+    };
+  }
 }
 
 export default metaDataProvider;

--- a/src/imageLoader/wadouri/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadouri/metaData/metaDataProvider.js
@@ -146,6 +146,14 @@ function metaDataProvider(type, imageId) {
   if (type === 'overlayPlaneModule') {
     return getOverlayPlaneModule(dataSet);
   }
+
+  // Note: this is not a DICOM module, but a useful metadata that can be
+  // retrieved from the image
+  if (type === 'transferSyntax') {
+    return {
+      transferSyntaxUID: dataSet.string('x00020010'),
+    };
+  }
 }
 
 export default metaDataProvider;


### PR DESCRIPTION
1. Cornerstone3D does not rely on A in the RGBA, this PR adds the option to not use it. 
2. Adds `transferSyntax` metadata return

