### PR TITLE
Wait until beforeSend header is returned before sending xhr request

### DIFF
--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -21,12 +21,18 @@ function xhrRequest(url, imageId, defaultHeaders = {}, params = {}) {
     const xhr = new XMLHttpRequest();
 
     xhr.open('get', url, true);
-    const beforeSendHeaders = options.beforeSend(
-      xhr,
-      imageId,
-      defaultHeaders,
-      params
-    );
+    
+    let beforeSendHeaders = {};
+    try{
+      beforeSendHeaders = options.beforeSend(
+        xhr,
+        imageId,
+        defaultHeaders,
+        params
+      );
+    } catch(err) {
+      console.error(err);
+    }
 
     xhr.responseType = 'arraybuffer';
 


### PR DESCRIPTION
In some cases, beforeSend method passes is asynchronous or returns a promise. For example, when the xhr request requires addition of an access token in the header and the retreival of the access token is done asynchronously, the beforeSend methos is therefore asynchronous. In this case, the current implementation does not wait for the header to be returned before sending the xhr request.