### PR TITLE
Documentation about CopyWebpackPlugin Needs an Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,17 @@ See
 for how we do it in OHIF Viewer.
 
 ```js
- plugins: [
-  new CopyWebpackPlugin([
-    {
-      from:
-        '../../../node_modules/cornerstone-wado-image-loader/dist/dynamic-import',
-      to: DIST_DIR,
-    },
-  ]),
+plugins: [
+    new CopyWebpackPlugin(
+        {
+          patterns: [
+            {
+                from: '../../../node_modules/cornerstone-wado-image-loader/dist/dynamic-import',
+                to: DIST_DIR,
+            }
+          ]
+        },
+      ),
 ```
 
 Note 1: You need to give the correct path in the `CopyWebpackPlugin`, the above


### PR DESCRIPTION
According to current docs, CopyWebpackPlugin is provided `from` and `to` fields. However trying this results in an error. Because since [version 6.0.0  of CopyWebpackPlugin](https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0), the plugin accepts an object in the format of `{patterns, options}` where `patterns` represents a list of patterns.