### PR TITLE
Update xhrRequest.js - await beforeSend function - asynchronous retrieval of JWT tokens from AWS Cognito or similar services.

### DIFF
--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -17,11 +17,11 @@ function xhrRequest(url, imageId, defaultHeaders = {}, params = {}) {
   };
 
   // Make the request for the DICOM P10 SOP Instance
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
     xhr.open('get', url, true);
-    const beforeSendHeaders = options.beforeSend(
+    const beforeSendHeaders = await options.beforeSend(
       xhr,
       imageId,
       defaultHeaders,


### PR DESCRIPTION
Hi,

I believe that the function in xhrRequest needs to be asynchronous, and always awaits on the beforeSend function. The reason why is sometimes JWT tokens expire if they are short lived, example 5-10 minutes, so It's not reliable to have a variable with the token assigned to it, we sometimes need to await a function call that retrieves new tokens using the refresh token from AWS cognito, It's probably a similar process for other cloud providers.

Assigning the JWT token to a variable doesn't work so well because the timing isn't always right and you sometimes end up making requests with expired tokens which end up getting denied by the backend. that's why it's better to use a function to retrieve the tokens.

![Screenshot_1](https://user-images.githubusercontent.com/93064150/188487468-810dc8cc-7d38-4cd6-b7d9-4582c006aad6.png)


This code below wouldn't work with how the current xhrRequest.js file is, since it doesn't await the beforeSend function

```
import { Auth } from "aws-amplify";
import cornerstoneWADOImageLoader from "cornerstone-wado-image-loader";

cornerstoneWADOImageLoader.configure({      
  beforeSend: async function (xhr) {
     xhr.setRequestHeader('Authorization', `${(await Auth.currentSession()).getIdToken().getJwtToken()}`);
       },
      }
```
It would lead to the following error

```
Uncaught (in promise) DOMException: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
    at Object.beforeSend

 ```

After the changes I have made to the xhrRequest.js everything works as intended since the function waits for beforeSend to retrieve the JWT tokens from AWS Cognito before proceeding.

A work around right now is to put the JWT tokens in the imageIds query parameters but that's really not best practice, It's best to be put in the Authorization headers of the request.

I hope this gets merged as I can see It's been proposed previously several times but never merged. 



