### PR TITLE
fix: use array of mediatypes and transferSyntax when calling a get xhrRequest for image loading

### DIFF
--- a/src/imageLoader/internal/xhrRequest.js
+++ b/src/imageLoader/internal/xhrRequest.js
@@ -21,6 +21,7 @@ function xhrRequest(url, imageId, defaultHeaders = {}, params = {}) {
     const xhr = new XMLHttpRequest();
 
     xhr.open('get', url, true);
+
     const beforeSendHeaders = options.beforeSend(
       xhr,
       imageId,
@@ -39,6 +40,7 @@ function xhrRequest(url, imageId, defaultHeaders = {}, params = {}) {
       if (key === 'Accept' && url.indexOf('accept=') !== -1) {
         return;
       }
+
       xhr.setRequestHeader(key, headers[key]);
     });
 

--- a/src/imageLoader/wadors/loadImage.js
+++ b/src/imageLoader/wadors/loadImage.js
@@ -72,21 +72,77 @@ function loadImage(imageId, options = {}) {
   const promise = new Promise((resolve, reject) => {
     // TODO: load bulk data items that we might need
 
-    // Uncomment this on to test jpegls codec in OHIF
-    // const mediaType = 'multipart/related; type="image/x-jls"';
-    // const mediaType = 'multipart/related; type="application/octet-stream"; transfer-syntax="image/x-jls"';
-    const mediaType =
-      'multipart/related; type=application/octet-stream; transfer-syntax=*';
-    // const mediaType =
-    //   'multipart/related; type="image/jpeg"; transfer-syntax=1.2.840.10008.1.2.4.50';
+    const xdicomrleMediaType = 'image/x-dicom-rle';
+    const xdicomrleTransferSyntaxUID = '1.2.840.10008.1.2.5';
+    const jpegMediaType = 'image/jpeg';
+    const jpegTransferSyntaxUID1 = '1.2.840.10008.1.2.4.50';
+    const jpegTransferSyntaxUID2 = '1.2.840.10008.1.2.4.51';
+    const jpegTransferSyntaxUIDlossless = '1.2.840.10008.1.2.4.57';
+    const jllMediaType = 'image/jll';
+    const jlllTransferSyntaxUIDlossless = '1.2.840.10008.1.2.4.70';
+    const jlsMediaType = 'image/jls';
+    const jlsTransferSyntaxUIDlossless = '1.2.840.10008.1.2.4.80';
+    const jlsTransferSyntaxUID = '1.2.840.10008.1.2.4.81';
+    const jp2MediaType = 'image/jp2';
+    const jp2TransferSyntaxUIDlossless = '1.2.840.10008.1.2.4.90';
+    const jp2TransferSyntaxUID = '1.2.840.10008.1.2.4.91';
+    const octetStreamMediaType = 'application/octet-stream';
+    const octetStreamTransferSyntaxUID = '*';
+    const mediaTypes = [];
 
-    function sendXHR(imageURI, imageId, mediaType) {
+    mediaTypes.push(
+      ...[
+        {
+          mediaType: xdicomrleMediaType,
+          transferSyntaxUID: xdicomrleTransferSyntaxUID,
+        },
+        {
+          mediaType: jpegMediaType,
+          transferSyntaxUID: jpegTransferSyntaxUID1,
+        },
+        {
+          mediaType: jpegMediaType,
+          transferSyntaxUID: jpegTransferSyntaxUID2,
+        },
+        {
+          mediaType: jpegMediaType,
+          transferSyntaxUID: jpegTransferSyntaxUIDlossless,
+        },
+        {
+          mediaType: jllMediaType,
+          transferSyntaxUID: jlllTransferSyntaxUIDlossless,
+        },
+        {
+          mediaType: jlsMediaType,
+          transferSyntaxUID: jlsTransferSyntaxUIDlossless,
+        },
+        {
+          mediaType: jlsMediaType,
+          transferSyntaxUID: jlsTransferSyntaxUID,
+        },
+        {
+          mediaType: jp2MediaType,
+          transferSyntaxUID: jp2TransferSyntaxUIDlossless,
+        },
+        {
+          mediaType: jp2MediaType,
+          transferSyntaxUID: jp2TransferSyntaxUID,
+        },
+        {
+          mediaType: octetStreamMediaType,
+          transferSyntaxUID: octetStreamTransferSyntaxUID,
+        },
+      ]
+    );
+
+    function sendXHR(imageURI, imageId, mediaTypes) {
       // get the pixel data from the server
-      return getPixelData(imageURI, imageId, mediaType)
+      return getPixelData(imageURI, imageId, mediaTypes)
         .then((result) => {
           const transferSyntax = getTransferSyntaxForContentType(
             result.contentType
           );
+
           const pixelData = result.imageFrame.pixelData;
           const imagePromise = createImage(
             imageId,
@@ -115,7 +171,7 @@ function loadImage(imageId, options = {}) {
     const uri = imageId.substring(7);
 
     imageRetrievalPool.addRequest(
-      sendXHR.bind(this, uri, imageId, mediaType),
+      sendXHR.bind(this, uri, imageId, mediaTypes),
       requestType,
       additionalDetails,
       priority,


### PR DESCRIPTION
Re IDC https://github.com/OHIF/Viewers/issues/2934

Related to https://github.com/OHIF/Viewers/issues/2934#issuecomment-1252758264

This implements the get image in xhrRequuests using an array of mediaTypes and TransferSyntax (analogous to SLIM viewer https://github.com/herrmannlab/dicom-microscopy-viewer/blob/83739f1ba11840df7f4487cdf8015b7450ee419d/src/pyramid.js#L436-L491 ), instead of always requesting as this default:
```
 const mediaType =
      'multipart/related; type=application/octet-stream; transfer-syntax=*';
```

Requesting images with type=application/octet-stream; transfer-syntax=* as default can create several issues. For example as in https://github.com/OHIF/Viewers/issues/2934, the 8 bit colored jpeg will be decoded server side (including color corrections), but then the returned mime and transfer syntax is 1.2.840.10008.1.2 instead of 1.2.840.10008.1.2.4.50 (because thhe array is already decoded), but at this point cornerstoneWADOLoader willl apply again color corrections (which is based on the photometric Interpretation of the image frame).

With this PR,  type=application/octet-stream; transfer-syntax=* will have lower priority and used only as last resource. 
For example, in the case of 8 bit colored jpeg, the images will be donwloaded in jpeg format and always decoded (and color transformations applied) client-side.