### PR TITLE
feat/multiframe

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,12 @@ module.exports = {
     SharedArrayBuffer: true,
   },
   rules: {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      },
+    ],    
     'no-debugger': 'off',
     'accessor-pairs': 'warn',
     'array-bracket-spacing': 'warn',

--- a/src/imageLoader/wadors/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadors/metaData/metaDataProvider.js
@@ -13,6 +13,23 @@ function metaDataProvider(type, imageId) {
     return;
   }
 
+  // adjust metadata in case of multifrme NM data
+  if (
+    metaData['00540022'] &&
+    metaData['00540022'].Value &&
+    metaData['00540022'].Value.length > 0
+  ) {
+    metaData['00200032'] = metaData['00540022'].Value[0]['00200032'];
+    metaData['00200037'] = metaData['00540022'].Value[0]['00200037'];
+  }
+
+  if (type === 'MultiframeModule') {
+    return {
+      SharedFunctionalGroupsSequence: getValue(metaData['52009229']),
+      NumberOfFrames: getValue(metaData['00280008']),
+    };
+  }
+
   if (type === 'generalSeriesModule') {
     return {
       modality: getValue(metaData['00080060']),

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -2,59 +2,64 @@ import imageIdToURI from '../imageIdToURI.js';
 
 let metadataByImageURI = [];
 
-function getValue(tag, justElement = true)
-{
-    if (tag.Value)
-    {
-       if (tag.Value[0] && justElement) 
-          return tag.Value[0]
-       else
-          return tag.Value;
+function getValue(tag, justElement = true) {
+  if (tag.Value) {
+    if (tag.Value[0] && justElement) {
+      return tag.Value[0];
     }
-    else
-       return tag;
-    
 
+    return tag.Value;
+  }
+
+  return tag;
 }
 
-function combineFrameInstance(frame, instance)  
-{
+function combineFrameInstance(frame, instance) {
   let {
-    '52009230' : PerFrameFunctionalGroupsSequence,
-    '52009229' : SharedFunctionalGroupsSequence,
-    '00280008' : NumberOfFrames,
+    52009230: PerFrameFunctionalGroupsSequence,
+    52009229: SharedFunctionalGroupsSequence,
+    '00280008': NumberOfFrames,
+    // eslint-disable-next-line prefer-const
     ...rest
   } = instance;
 
-  PerFrameFunctionalGroupsSequence = getValue(PerFrameFunctionalGroupsSequence, false);
-  SharedFunctionalGroupsSequence = getValue(SharedFunctionalGroupsSequence, false);
+  PerFrameFunctionalGroupsSequence = getValue(
+    PerFrameFunctionalGroupsSequence,
+    false
+  );
+  SharedFunctionalGroupsSequence = getValue(
+    SharedFunctionalGroupsSequence,
+    false
+  );
   NumberOfFrames = getValue(NumberOfFrames);
 
   if (PerFrameFunctionalGroupsSequence || NumberOfFrames > 1) {
-    const frameNumber = Number.parseInt(frame || 1);
-    const shared = (SharedFunctionalGroupsSequence
-      ? Object.values(SharedFunctionalGroupsSequence[0])
-      : []
+    const frameNumber = Number.parseInt(frame || 1, 10);
+    const shared = (
+      SharedFunctionalGroupsSequence
+        ? Object.values(SharedFunctionalGroupsSequence[0])
+        : []
     )
-      .map(it => it[0])
-      .filter(it => it !== undefined && typeof it === 'object');
-    const perFrame = (PerFrameFunctionalGroupsSequence
-      ? Object.values(PerFrameFunctionalGroupsSequence[frameNumber - 1])
-      : []
+      .map((it) => it[0])
+      .filter((it) => it !== undefined && typeof it === 'object');
+    const perFrame = (
+      PerFrameFunctionalGroupsSequence
+        ? Object.values(PerFrameFunctionalGroupsSequence[frameNumber - 1])
+        : []
     )
-      .map(it => it.Value[0])
-      .filter(it => it !== undefined && typeof it === 'object');
+      .map((it) => it.Value[0])
+      .filter((it) => it !== undefined && typeof it === 'object');
 
     return Object.assign(
-      { frameNumber: frameNumber },
+      { frameNumber },
       rest,
       ...Object.values(shared),
       ...Object.values(perFrame)
     );
-  } else {
-    return instance;
   }
-};
+
+  return instance;
+}
 
 function add(imageId, metadata) {
   const imageURI = imageIdToURI(imageId);
@@ -64,15 +69,26 @@ function add(imageId, metadata) {
 
 function get(imageId) {
   const imageURI = imageIdToURI(imageId);
+
   let metadata = metadataByImageURI[imageURI];
-  if (!metadata)  // in this case try see if the imageId corresponds to multiframe
-  {
-     const imageIdFrameless = imageURI.slice(0, imageURI.indexOf('/frames/')+8);
-     const frame = parseInt(imageURI.slice(imageURI.indexOf('/frames/')+9));
-     metadata = metadataByImageURI[imageIdFrameless + '1'];
-     if (metadata)
-        metadata = combineFrameInstance(frame, metadata);
+
+  if (!metadata) {
+    // in this case try see if the imageId corresponds to multiframe
+    const imageIdFrameless = imageURI.slice(
+      0,
+      imageURI.indexOf('/frames/') + 8
+    );
+    const frame = parseInt(
+      imageURI.slice(imageURI.indexOf('/frames/') + 9),
+      10
+    );
+
+    metadata = metadataByImageURI[`${imageIdFrameless}1`];
+    if (metadata) {
+      metadata = combineFrameInstance(frame, metadata);
+    }
   }
+
   return metadata;
 }
 

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -105,6 +105,7 @@ function purge() {
 export default {
   add,
   get,
+  getValue,
   remove,
   purge,
 };

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -3,12 +3,14 @@ import imageIdToURI from '../imageIdToURI.js';
 let metadataByImageURI = [];
 
 function getValue(tag, justElement = true) {
-  if (tag.Value) {
-    if (tag.Value[0] && justElement) {
-      return tag.Value[0];
-    }
+  if (tag) {
+    if (tag.Value) {
+      if (tag.Value[0] && justElement) {
+        return tag.Value[0];
+      }
 
-    return tag.Value;
+      return tag.Value;
+    }
   }
 
   return tag;

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -53,7 +53,6 @@ function combineFrameInstance(frame, instance) {
       .filter((it) => it !== undefined && typeof it === 'object');
 
     return Object.assign(
-      { frameNumber },
       rest,
       ...Object.values(shared),
       ...Object.values(perFrame)

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -2,6 +2,60 @@ import imageIdToURI from '../imageIdToURI.js';
 
 let metadataByImageURI = [];
 
+function getValue(tag, justElement = true)
+{
+    if (tag.Value)
+    {
+       if (tag.Value[0] && justElement) 
+          return tag.Value[0]
+       else
+          return tag.Value;
+    }
+    else
+       return tag;
+    
+
+}
+
+function combineFrameInstance(frame, instance)  
+{
+  let {
+    '52009230' : PerFrameFunctionalGroupsSequence,
+    '52009229' : SharedFunctionalGroupsSequence,
+    '00280008' : NumberOfFrames,
+    ...rest
+  } = instance;
+
+  PerFrameFunctionalGroupsSequence = getValue(PerFrameFunctionalGroupsSequence, false);
+  SharedFunctionalGroupsSequence = getValue(SharedFunctionalGroupsSequence, false);
+  NumberOfFrames = getValue(NumberOfFrames);
+
+  if (PerFrameFunctionalGroupsSequence || NumberOfFrames > 1) {
+    const frameNumber = Number.parseInt(frame || 1);
+    const shared = (SharedFunctionalGroupsSequence
+      ? Object.values(SharedFunctionalGroupsSequence[0])
+      : []
+    )
+      .map(it => it[0])
+      .filter(it => it !== undefined && typeof it === 'object');
+    const perFrame = (PerFrameFunctionalGroupsSequence
+      ? Object.values(PerFrameFunctionalGroupsSequence[frameNumber - 1])
+      : []
+    )
+      .map(it => it.Value[0])
+      .filter(it => it !== undefined && typeof it === 'object');
+
+    return Object.assign(
+      { frameNumber: frameNumber },
+      rest,
+      ...Object.values(shared),
+      ...Object.values(perFrame)
+    );
+  } else {
+    return instance;
+  }
+};
+
 function add(imageId, metadata) {
   const imageURI = imageIdToURI(imageId);
 
@@ -10,8 +64,16 @@ function add(imageId, metadata) {
 
 function get(imageId) {
   const imageURI = imageIdToURI(imageId);
-
-  return metadataByImageURI[imageURI];
+  let metadata = metadataByImageURI[imageURI];
+  if (!metadata)  // in this case try see if the imageId corresponds to multiframe
+  {
+     const imageIdFrameless = imageURI.slice(0, imageURI.indexOf('/frames/')+8);
+     const frame = parseInt(imageURI.slice(imageURI.indexOf('/frames/')+9));
+     metadata = metadataByImageURI[imageIdFrameless + '1'];
+     if (metadata)
+        metadata = combineFrameInstance(frame, metadata);
+  }
+  return metadata;
 }
 
 function remove(imageId) {


### PR DESCRIPTION
This pull request enables the wado loader to work with multi-frame images.
It changes the metadataManager.js and expects imageids with frames/1, frames/2, indicating the frame needed. 
The function to convert a list of multiframe imageids to a list of imageids with frame number can be found in the /utils/demo/helpers/convertMultiframeImageIds.js in a PR of cornerstone-beta