### PR TITLE
adding suppoort for multiframe in cswil

### DIFF
--- a/src/imageLoader/wadors/metaData/metaDataProvider.js
+++ b/src/imageLoader/wadors/metaData/metaDataProvider.js
@@ -13,6 +13,23 @@ function metaDataProvider(type, imageId) {
     return;
   }
 
+  // adjust metadata in case of multifrme NM data
+  if (
+    metaData['00540022'] &&
+    metaData['00540022'].Value &&
+    metaData['00540022'].Value.length > 0
+  ) {
+    metaData['00200032'] = metaData['00540022'].Value[0]['00200032'];
+    metaData['00200037'] = metaData['00540022'].Value[0]['00200037'];
+  }
+
+  if (type === 'MultiframeModule') {
+    return {
+      SharedFunctionalGroupsSequence: getValue(metaData['52009229']),
+      NumberOfFrames: getValue(metaData['00280008']),
+    };
+  }
+
   if (type === 'generalSeriesModule') {
     return {
       modality: getValue(metaData['00080060']),

--- a/src/imageLoader/wadors/metaDataManager.js
+++ b/src/imageLoader/wadors/metaDataManager.js
@@ -2,6 +2,66 @@ import imageIdToURI from '../imageIdToURI.js';
 
 let metadataByImageURI = [];
 
+function getValue(tag, justElement = true) {
+  if (tag) {
+    if (tag.Value) {
+      if (tag.Value[0] && justElement) {
+        return tag.Value[0];
+      }
+
+      return tag.Value;
+    }
+  }
+
+  return tag;
+}
+
+function combineFrameInstance(frame, instance) {
+  let {
+    52009230: PerFrameFunctionalGroupsSequence,
+    52009229: SharedFunctionalGroupsSequence,
+    '00280008': NumberOfFrames,
+    // eslint-disable-next-line prefer-const
+    ...rest
+  } = instance;
+
+  PerFrameFunctionalGroupsSequence = getValue(
+    PerFrameFunctionalGroupsSequence,
+    false
+  );
+  SharedFunctionalGroupsSequence = getValue(
+    SharedFunctionalGroupsSequence,
+    false
+  );
+  NumberOfFrames = getValue(NumberOfFrames);
+
+  if (PerFrameFunctionalGroupsSequence || NumberOfFrames > 1) {
+    const frameNumber = Number.parseInt(frame || 1, 10);
+    const shared = (
+      SharedFunctionalGroupsSequence
+        ? Object.values(SharedFunctionalGroupsSequence[0])
+        : []
+    )
+      .map((it) => it[0])
+      .filter((it) => it !== undefined && typeof it === 'object');
+    const perFrame = (
+      PerFrameFunctionalGroupsSequence
+        ? Object.values(PerFrameFunctionalGroupsSequence[frameNumber - 1])
+        : []
+    )
+      .map((it) => it.Value[0])
+      .filter((it) => it !== undefined && typeof it === 'object');
+
+    return Object.assign(
+      rest,
+      ...Object.values(shared),
+      ...Object.values(perFrame)
+    );
+  }
+
+  return instance;
+}
+
 function add(imageId, metadata) {
   const imageURI = imageIdToURI(imageId);
 
@@ -11,7 +71,26 @@ function add(imageId, metadata) {
 function get(imageId) {
   const imageURI = imageIdToURI(imageId);
 
-  return metadataByImageURI[imageURI];
+  let metadata = metadataByImageURI[imageURI];
+
+  if (!metadata) {
+    // in this case try see if the imageId corresponds to multiframe
+    const imageIdFrameless = imageURI.slice(
+      0,
+      imageURI.indexOf('/frames/') + 8
+    );
+    const frame = parseInt(
+      imageURI.slice(imageURI.indexOf('/frames/') + 9),
+      10
+    );
+
+    metadata = metadataByImageURI[`${imageIdFrameless}1`];
+    if (metadata) {
+      metadata = combineFrameInstance(frame, metadata);
+    }
+  }
+
+  return metadata;
 }
 
 function remove(imageId) {
@@ -27,6 +106,7 @@ function purge() {
 export default {
   add,
   get,
+  getValue,
   remove,
   purge,
 };


### PR DESCRIPTION
This pull request enables the wado loader to work with multi-frame images.
It changes the metadataManager.js and expects imageids with frames/1, frames/2, indicating the frame needed.
The function to convert a list of multiframe imageids to a list of imageids with frame number can be found in the /utils/demo/helpers/convertMultiframeImageIds.js in a PR of cornerstone-beta