### PR TITLE
fix: blurry pixels bug for decoding of jpeg2000

### DIFF
--- a/src/shared/decoders/decodeJPEG2000.js
+++ b/src/shared/decoders/decodeJPEG2000.js
@@ -44,6 +44,8 @@ export function initialize(decodeConfig) {
 async function decodeAsync(compressedImageFrame, imageInfo) {
   await initialize();
   const decoder = local.decoder;
+  const decodeLevel = 0;
+  const decodeLayer = 0;
 
   // get pointer to the source/encoded bit stream buffer in WASM memory
   // that can hold the encoded bitstream
@@ -55,8 +57,8 @@ async function decodeAsync(compressedImageFrame, imageInfo) {
   encodedBufferInWASM.set(compressedImageFrame);
 
   // decode it
-  decoder.decode();
-  // decoder.decodeSubResolution(decodeLevel, decodeLayer);
+  // decoder.decode();
+  decoder.decodeSubResolution(decodeLevel, decodeLayer);
   // const resolutionAtLevel = decoder.calculateSizeAtDecompositionLevel(decodeLevel);
 
   // get information about the decoded image


### PR DESCRIPTION
Switching j2k decoder to wasm had introduced a pixelated/blury bug for some images. 

Reported here:
- https://github.com/cornerstonejs/cornerstoneWADOImageLoader/issues/475
- https://github.com/cornerstonejs/cornerstone3D-beta/issues/256
- https://github.com/OHIF/Viewers/issues/2958

Data by community can be found here
- https://www.dropbox.com/sh/19ov4r7r6usikub/AAApGg0AhdD6piAFgguHTEvWa?dl=0

Steps taken discussed [here](https://github.com/cornerstonejs/codecs/issues/18) 


CC @swederik @heyflynn @kunjesh1 @lambacini , try here https://deploy-preview-497--cornerstone-wado-image-loader.netlify.app/dicomfile/index.html

Also Chris @chafey just fixed the decode problem [here](https://github.com/chafey/openjpegjs/commits/master) which I will use in codecs
