### PR TITLE
fix: data type view after scaling

### DIFF
--- a/src/imageLoader/createImage.js
+++ b/src/imageLoader/createImage.js
@@ -54,11 +54,17 @@ function convertToIntPixelData(floatPixelData) {
  * can transfer array buffers but not typed arrays
  * @param imageFrame
  */
-function setPixelDataType(imageFrame) {
+function setPixelDataType(imageFrame, preScale) {
+  const isScaled = preScale?.scaled;
+  const scalingParmeters = preScale?.scalingParameters;
+  const rescaleSlope = scalingParmeters?.rescaleSlope;
+  const rescaleIntercept = scalingParmeters?.rescaleIntercept;
+  const isNegative = rescaleSlope < 0 || rescaleIntercept < 0;
+
   if (imageFrame.bitsAllocated === 32) {
     imageFrame.pixelData = new Float32Array(imageFrame.pixelData);
   } else if (imageFrame.bitsAllocated === 16) {
-    if (imageFrame.pixelRepresentation === 0) {
+    if (imageFrame.pixelRepresentation === 0 && !(isScaled && isNegative)) {
       imageFrame.pixelData = new Uint16Array(imageFrame.pixelData);
     } else {
       imageFrame.pixelData = new Int16Array(imageFrame.pixelData);
@@ -219,7 +225,7 @@ function createImage(imageId, pixelData, transferSyntax, options = {}) {
       }
 
       if (!alreadyTyped) {
-        setPixelDataType(imageFrame);
+        setPixelDataType(imageFrame, imageFrame.preScale);
       }
 
       const imagePlaneModule =


### PR DESCRIPTION
@sedghi @swederik, I was going through to make sure CSWIL would automatically select the proper type for cs3d and think there might be a bug. I could very likely wrong though since afaik no such issue has been reported...

Essentially, cs3d will rely on the native decoded array type CSWIL provides. In the case the PixelData is `PixelRepresentation === 0`, it is usually a `Uint16ArrayBuffer` view for CT data. However, usually this data is preScaled within CSWIL and after scaling, a `Uint16ArrayBuffer` view should really be a `Int16ArrayBuffer`. However, it does not seem like this view is used in the `setPixelDataType` function.

It seems like PixelRepresentation also only refers to the stored pixel data tag, not post slope + intercept. (https://groups.google.com/g/comp.protocols.dicom/c/LQv-Vq8fQYA)

A `Uint16` view can easily be recast to `Int16` view downstream, which may be why no issues have popped up thus far?

Let me know if I'm missing anything here as I'm a bit confused how a Uint16 typed PixelData + rescale would provide back a proper `imageFrame.pixelData` without the changes below.