### PR TITLE
fix(bundle): include codecs chunks into bundle in bundle mode

### DIFF
--- a/config/webpack/webpack-bundle.js
+++ b/config/webpack/webpack-bundle.js
@@ -89,7 +89,12 @@ module.exports = {
       },
     ],
   },
-  plugins: [new webpack.ProgressPlugin()],
+  plugins: [
+    new webpack.ProgressPlugin(),
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
+  ],
   experiments: {
     asyncWebAssembly: true,
   },


### PR DESCRIPTION
previously `webpack:bundle` script created `610.bundle.min.js` and `888.bundle.min.js` files that caused incorrect referencing in other applications (examples: [ #511 , #479 , #439 ]).

Updated webpack config to include all chunks together. Actually, this approanch helped with incorrect referencing in embedded OHIF Viewer that we're using in our app

Previous dist build:
![image](https://user-images.githubusercontent.com/42917304/225910629-b850cf24-e127-4507-bd83-b9338dee32f2.png)

Current dist build:
![MoMAAZXepB](https://user-images.githubusercontent.com/42917304/225915883-fc5cbfbf-8a35-4d6a-bd18-dfa1f96c59e7.png)

