### PR TITLE
Fix Multifrmae image index

### DIFF
--- a/src/imageLoader/wadouri/loadImage.js
+++ b/src/imageLoader/wadouri/loadImage.js
@@ -153,7 +153,7 @@ function loadImage(imageId, options = {}) {
     return loadImageFromDataSet(
       dataSet,
       imageId,
-      parsedImageId.frame,
+      Math.max(0, parsedImageId.frame - 1),
       parsedImageId.url,
       options
     );
@@ -169,7 +169,7 @@ function loadImage(imageId, options = {}) {
   return loadImageFromPromise(
     dataSetPromise,
     imageId,
-    parsedImageId.frame,
+    Math.max(0, parsedImageId.frame - 1),
     parsedImageId.url,
     options
   );


### PR DESCRIPTION
The multiframe update enabled handling of multiframe metadata, but the image index is 0 based and metadata index 1 based. So we proposed this update to synchronize both indexes and get the correct image based on the frame number in the url