### PR TITLE
fix(suv display): fix scaling of non-SUV PT images

### DIFF
--- a/src/shared/scaling/scaleArray.js
+++ b/src/shared/scaling/scaleArray.js
@@ -2,11 +2,7 @@ export default function scaleArray(array, scalingParameters) {
   const arrayLength = array.length;
   const { rescaleSlope, rescaleIntercept, suvbw } = scalingParameters;
 
-  if (scalingParameters.modality === 'PT') {
-    if (typeof suvbw !== 'number') {
-      return;
-    }
-
+  if (scalingParameters.modality === 'PT' && typeof suvbw === 'number') {
     for (let i = 0; i < arrayLength; i++) {
       array[i] = suvbw * (array[i] * rescaleSlope + rescaleIntercept);
     }


### PR DESCRIPTION
Currently PT images that are not in SUV are not rescaled at all. This is problematic because PT images can be in units of e.g. counts or Bq/ml, so it's important that the rescaling is applied in those cases.

cc @sedghi this is the same fix as in https://github.com/cornerstonejs/cornerstone3D-beta/pull/536